### PR TITLE
puppetlabs-translate is being deprecated

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -19,9 +19,6 @@ fixtures:
     puppet_agent:
       repo: "puppetlabs-puppet_agent"
       ref: "3.0.2"
-    translate:
-      repo: "puppetlabs-translate"
-      ref: "2.1.0"
     registry:
       repo: "puppetlabs-registry"
       ref: "3.1.0"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -56,7 +56,7 @@ class sshkeymgmt(
 
     if(empty($authorized_keys_owner) or empty($authorized_keys_group) or
       empty($authorized_keys_permissions) or empty($authorized_keys_base_dir_permissions)) {
-      fail(translate('authorized_keys_owner, authorized_keys_group, authorized_keys_base_dir_permissions and authorized_keys_permissions must be set as well!')) #lint:ignore:140chars
+      fail('authorized_keys_owner, authorized_keys_group, authorized_keys_base_dir_permissions and authorized_keys_permissions must be set as well!') #lint:ignore:140chars
     }
 
     file{$authorized_keys_base_dir:


### PR DESCRIPTION
Hey Tom! We are deprecating the translate module and noticed that you're
using it here.